### PR TITLE
fix: partialにmessageを追加

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import task, { monitorReactions } from './commands/task';
 
 const client = new Client({
     intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildMessageReactions],
-    partials: [Partials.Reaction]
+    partials: [Partials.Message, Partials.Reaction]
 });
 
 client.once('ready', () => {


### PR DESCRIPTION
ドキュメントで見つけられなかったのでなぜかはわからないのですが、おそらく `reaction` に `message` が含まれているので、`message` がキャッシュに無くても無視されないようにするためには `Partials.Message` も必要っぽいです
探したらどっかに理由あるとは思うんですが見つけられてなく